### PR TITLE
嵌套文件扫描

### DIFF
--- a/README.md
+++ b/README.md
@@ -117,6 +117,7 @@ docker run --rm -v /var/run/docker.sock:/var/run/docker.sock containrrr/watchtow
     "QYWX_AM": "",
     "其他推送渠道//此项可删": "配置方法同青龙"
   },
+  "allowSubDirectoryRegList": [], // 正则列表，用于子目录递归更新，一些资源中会分为4K、1080P等， 就可以配置 ["4k","1080p"], 这样遇到这些文件夹的时候也会进行资源更新
   "emby": {
     "url": "http://yourdomain.com:8096",
     "apikey": "" //在后台 高级-API秘钥 中生成

--- a/README.md
+++ b/README.md
@@ -117,7 +117,6 @@ docker run --rm -v /var/run/docker.sock:/var/run/docker.sock containrrr/watchtow
     "QYWX_AM": "",
     "其他推送渠道//此项可删": "配置方法同青龙"
   },
-  "allowSubDirectoryRegList": [], // 正则列表，用于子目录递归更新，一些资源中会分为4K、1080P等， 就可以配置 ["4k","1080p"], 这样遇到这些文件夹的时候也会进行资源更新
   "emby": {
     "url": "http://yourdomain.com:8096",
     "apikey": "" //在后台 高级-API秘钥 中生成
@@ -133,6 +132,7 @@ docker run --rm -v /var/run/docker.sock:/var/run/docker.sock containrrr/watchtow
       "emby_id": "",            //可选，缺省时按taskname搜索匹配，为0时强制不匹配
       "ignore_extension": true, //可选，忽略后缀
       "runweek": [1, 2, 3, 4, 6, 7], //可选，指定星期几执行，无此字段则均执行
+      "update_subdir": "", // 可选，子目录递归更新的正则表达式，如 "4k|1080p"
       // 以下字段无需配置
       "shareurl_ban": "分享地址已失效" //记录分享是否失效；如有此字段将跳过任务，更新链接后请手动删去
     }

--- a/quark_auto_save.py
+++ b/quark_auto_save.py
@@ -439,7 +439,7 @@ class Quark:
             if os.environ.get("DEBUG") == True:
                 print(f"转存测试失败: {str(e)}")
 
-    def do_save_task(self, task):
+    def do_save_task(self, task, folder_id=False, folder_path=False):
         # 判断资源失效记录
         if task.get("shareurl_ban"):
             print(f"《{task['taskname']}》：{task['shareurl_ban']}")
@@ -458,7 +458,7 @@ class Quark:
         # print("stoken: ", stoken)
 
         # 获取分享文件列表
-        share_file_list = self.get_detail(pwd_id, stoken, pdir_fid)
+        share_file_list = self.get_detail(pwd_id, stoken, folder_id or pdir_fid)
         # 仅有一个文件夹
         if len(share_file_list) == 1 and share_file_list[0]["dir"]:
             print("🧠 该分享是一个文件夹，读取文件夹内列表")
@@ -469,7 +469,7 @@ class Quark:
         # print("share_file_list: ", share_file_list)
 
         # 获取目标目录文件列表
-        savepath = task["savepath"]
+        savepath = folder_path or task["savepath"]
         if not self.savepath_fid.get(savepath):
             self.savepath_fid[savepath] = self.get_fids([savepath])[0]["fid"]
         to_pdir_fid = self.savepath_fid[savepath]
@@ -503,6 +503,8 @@ class Quark:
                     )
                     for dir_file in dir_file_list
                 )
+                if file_exists and share_file['dir'] == True:
+                    self.do_save_task(task, share_file['fid'] , task["savepath"] + '/' + share_file['file_name'])
                 if not file_exists:
                     share_file["save_name"] = save_name
                     need_save_list.append(share_file)

--- a/quark_auto_save.py
+++ b/quark_auto_save.py
@@ -439,7 +439,7 @@ class Quark:
             if os.environ.get("DEBUG") == True:
                 print(f"转存测试失败: {str(e)}")
 
-    def do_save_task(self, task, folder_id=False, folder_path=False):
+    def do_save_task(self, task, folder_id = False, folder_path = False):
         # 判断资源失效记录
         if task.get("shareurl_ban"):
             print(f"《{task['taskname']}》：{task['shareurl_ban']}")
@@ -463,7 +463,7 @@ class Quark:
         if len(share_file_list) == 1 and share_file_list[0]["dir"]:
             print("🧠 该分享是一个文件夹，读取文件夹内列表")
             share_file_list = self.get_detail(pwd_id, stoken, share_file_list[0]["fid"])
-        if not share_file_list:
+        if not share_file_list and not folder_path:
             add_notify(f"《{task['taskname']}》：分享目录为空")
             return
         # print("share_file_list: ", share_file_list)
@@ -504,7 +504,13 @@ class Quark:
                     for dir_file in dir_file_list
                 )
                 if file_exists and share_file['dir'] == True:
-                    self.do_save_task(task, share_file['fid'] , task["savepath"] + '/' + share_file['file_name'])
+                    # allowSubDirectoryRegList 是一个正则列表，其中只要有一个正则匹配成功，就执行do_save_task
+                    allowSubDirectoryRegList = CONFIG_DATA.get('allowSubDirectoryRegList')
+                    if allowSubDirectoryRegList:
+                        for reg in allowSubDirectoryRegList:
+                            if re.search(reg, share_file["file_name"], re.I):
+                                self.do_save_task(task, share_file['fid'], (folder_path or task["savepath"]) + '/' + share_file['file_name'])
+                                break
                 if not file_exists:
                     share_file["save_name"] = save_name
                     need_save_list.append(share_file)

--- a/quark_config.json
+++ b/quark_config.json
@@ -10,7 +10,6 @@
     "url": "",
     "apikey": ""
   },
-  "allowSubDirectoryRegList": [],
   "tasklist": [
     {
       "taskname": "测试-魔法匹配剧集（这是一组有效分享，配置CK后可测试任务是否正常）",
@@ -19,7 +18,8 @@
       "pattern": "$TV",
       "replace": "",
       "enddate": "2099-01-30",
-      "emby_id": ""
+      "emby_id": "",
+      "update_subdir": "4k|1080p"
     },
     {
       "taskname": "测试-广告过滤",

--- a/quark_config.json
+++ b/quark_config.json
@@ -10,6 +10,7 @@
     "url": "",
     "apikey": ""
   },
+  "allowSubDirectoryRegList": [],
   "tasklist": [
     {
       "taskname": "测试-魔法匹配剧集（这是一组有效分享，配置CK后可测试任务是否正常）",


### PR DESCRIPTION
:sparkles: 支持嵌套文件扫描
:sparkles: 为了避免深层扫描任务强度过大，增加配置allowSubDirectoryRegList，符合规则的子目录才进行递归扫描