### PR TITLE
关键词过滤修正

### DIFF
--- a/app/templates/index.html
+++ b/app/templates/index.html
@@ -302,6 +302,20 @@
                       </datalist>
                     </div>
                   </div>
+                  <div class="form-group row" title="用于过滤不需要的文件，符合正则表达式的文件将被排除">
+                    <label class="col-sm-2 col-form-label">过滤规则</label>
+                    <div class="col-sm-10">
+                      <div class="input-group">
+                        <div class="input-group-prepend">
+                          <span class="input-group-text">过滤正则</span>
+                        </div>
+                        <input type="text" name="filter_regex[]" class="form-control" v-model="task.filter_regex" placeholder="过滤表达式">
+                        <div class="input-group-append">
+                          <button type="button" class="btn btn-outline-secondary" @click="convertToRegex(task)">转换</button>
+                        </div>
+                      </div>
+                    </div>
+                  </div>
                   <div class="form-group row" title="只转存修改日期>选中文件的文件，在容量不够或几百集动漫的场景下非常有用">
                     <label class="col-sm-2 col-form-label">文件起始</label>
                     <div class="col-sm-10">
@@ -446,6 +460,7 @@
           savepath: "/",
           pattern: "",
           replace: "",
+          filter_regex: "",
           enddate: "",
           addition: {},
           ignore_extension: false,
@@ -824,6 +839,13 @@
             this.$delete(this.formData.magic_regex, key);
           }
         },
+        convertToRegex(task) {
+          // 使用正则表达式分割中英文逗号
+          const words = task.filter_regex.split(/[,，]/).map(word => word.trim());
+          // 构建"并且"逻辑的正则表达式
+          const regex = `^.*(${words.join('|')}).*`;
+          task.filter_regex = regex;
+        }
       }
     });
   </script>

--- a/quark_auto_save.py
+++ b/quark_auto_save.py
@@ -36,10 +36,6 @@ MAGIC_REGEX = {
         "pattern": r".*?(?<!\d)([Ss]\d{1,2})?([Ee]?[Pp]?[Xx]?\d{1,3})(?!\d).*?\.(mp4|mkv)",
         "replace": r"\1\2.\3",
     },
-    "$BLACK_WORD": {
-        "pattern": r"^(?!.*纯享)(?!.*加更)(?!.*超前企划)(?!.*训练室)(?!.*蒸蒸日上).*",
-        "replace": "",
-    },
 }
 
 
@@ -673,6 +669,11 @@ class Quark:
         need_save_list = []
         # 添加符合的
         for share_file in share_file_list:
+            # 检查过滤规则
+            if task.get("filter_regex") and re.search(task["filter_regex"], share_file["file_name"]):
+                print(f"跳过文件（过滤规则）：{share_file['file_name']}")
+                continue
+                
             if share_file["dir"] and task.get("update_subdir", False):
                 pattern, replace = task["update_subdir"], ""
             else:

--- a/quark_auto_save.py
+++ b/quark_auto_save.py
@@ -671,7 +671,6 @@ class Quark:
         for share_file in share_file_list:
             # 检查过滤规则
             if task.get("filter_regex") and re.search(task["filter_regex"], share_file["file_name"]):
-                print(f"跳过文件（过滤规则）：{share_file['file_name']}")
                 continue
                 
             if share_file["dir"] and task.get("update_subdir", False):


### PR DESCRIPTION
现有问题：BLACK_WORD的关键词过滤规则和自动命名的保存规则不能同时使用。

修正：在index页面增加关键词转换为filter_regex正则表达式功能，在转存脚本中使用。

效果（跳过文件提示仅用此处参考，实际运行中已删除）
![image](https://github.com/user-attachments/assets/db6bca59-1c92-4aa1-91c7-d0a1f0671252)
