### PR TITLE
递归检查也许不如重新转存

### DIFF
--- a/quark_auto_save.py
+++ b/quark_auto_save.py
@@ -671,6 +671,17 @@ class Quark:
         to_pdir_fid = self.savepath_fid[savepath]
         dir_file_list = self.ls_dir(to_pdir_fid)
         # print("dir_file_list: ", dir_file_list)
+        # 清空目标文件夹
+        fid_list = [item["fid"] for item in dir_file_list]
+        if fid_list:
+            self.delete(fid_list)
+            recycle_list = self.recycle_list()
+            record_id_list = [
+                item["record_id"] for item in recycle_list if item["fid"] in fid_list
+            ]
+            self.recycle_remove(record_id_list)
+        # 重新获取目标目录文件列表
+        dir_file_list = self.ls_dir(to_pdir_fid)
 
         tree.create_node(
             savepath,


### PR DESCRIPTION
对于深层嵌套文件夹，递归检查更新不如直接删除之前的转存并重新进行转存。也就是说可以添加一个选项，在每次定时任务时不进行对比检查而是直接重新转存。