### PR TITLE
修复魔法变量 {II} 不在开头时剧集重复保存的问题

### DIFF
--- a/quark_auto_save.py
+++ b/quark_auto_save.py
@@ -323,7 +323,7 @@ class MagicRename:
             filename = os.path.splitext(filename)[0]
             filename_list = [os.path.splitext(f)[0] for f in filename_list]
         # {I+} 模式，用I通配数字序号
-        if match := re.match(r"\{I+\}", filename):
+        if match := re.search(r"\{I+\}", filename):
             magic_i = match.group()
             pattern_i = r"\d" * magic_i.count("I")
             pattern = filename.replace(magic_i, pattern_i)


### PR DESCRIPTION
修复魔法变量 {II} 不在开头时剧集重复保存的问题，问题具体描述见 [issue](https://github.com/Cp0204/quark-auto-save/issues/84)。

根据魔法变量 {II} 的介绍说明“排序自增数字，几个 I 即几位数，**需把有一些规律字符往前放**”，不确定此处是否有意如此设计。