### PR TITLE
添加飞牛影视媒体库刷新插件

### DIFF
--- a/plugins/fnv.py
+++ b/plugins/fnv.py
@@ -1,0 +1,266 @@
+import requests
+import json
+import hashlib
+import random
+import time
+from urllib.parse import urlencode, urlsplit
+from typing import Any, Optional
+
+
+class Fnv:
+    default_config = {
+        "base_url": "http://10.0.0.6:5666",  # 飞牛影视服务器URL
+        "app_name": "trimemedia-web",  # 飞牛影视应用名称
+        "username": "",  # 飞牛影视用户名
+        "password": "",  # 飞牛影视密码
+        "secret_string": "",  # 飞牛影视密钥字符串
+        "api_key": "",  # 飞牛影视API密钥
+    }
+
+    default_task_config = {
+        "auto_refresh": False,  # 是否自动刷新媒体库
+        "mdb_name": "",  # 飞牛影视目标媒体库名称
+    }
+
+    is_active = False
+    token = None
+    session = requests.Session()
+
+    def __init__(self, **kwargs):
+        self.plugin_name = self.__class__.__name__.lower()
+        if kwargs:
+            for key, _ in self.default_config.items():
+                if key in kwargs:
+                    setattr(self, key, kwargs[key])
+            self.is_active = self._check_config()
+
+    def _check_config(self):
+        """检查配置是否完整"""
+        missing_keys = [
+            key for key in self.default_config if not getattr(self, key, None)
+        ]
+        if missing_keys:
+            print(f"{self.plugin_name} 模块缺少必要参数: {', '.join(missing_keys)}")
+            return False
+        return True
+
+    def run(self, task, **kwargs):
+        """插件运行主入口"""
+        if not self.is_active:
+            return
+        task_config = task.get("addition", {}).get(
+            self.plugin_name, self.default_task_config
+        )
+        if not task_config.get("auto_refresh"):
+            print("飞牛影视: 自动刷新未启用，跳过处理")
+            return
+        if not task_config.get("mdb_name"):
+            print("飞牛影视: 未指定媒体库名称，跳过处理")
+            return
+        target_library_name = task_config["mdb_name"]
+        app_name = self.app_name or self.default_config["app_name"]
+        username = self.username or self.default_config["username"]
+        password = self.password or self.default_config["password"]
+
+        # 登录并执行后续操作
+        if self._login(username=username, password=password, app_name=app_name):
+
+            # 登录成功后，获取媒体库ID
+            library_id = self._get_library_id(target_library_name)
+
+            if library_id:
+                # 获取ID成功后，刷新该媒体库
+                self._refresh_library(library_id)
+
+    def _make_request(self, method: str, rel_url: str, params: dict = None, data: dict = None) -> Optional[Any]:
+        """
+        一个统一的私有方法，用于发送所有API请求。
+        它会自动处理签名、请求头、错误和响应解析。
+        """
+        url = f"{self.base_url.rstrip('/')}{rel_url}"
+
+        # 1. 生成认证签名
+        authx = self._cse_sign(method, rel_url, params, data)
+        if not authx:
+            print(f"飞牛影视: 为 {rel_url} 生成签名失败，请求中止。")
+            return None
+
+        # 2. 准备请求头
+        headers = {
+            "Content-Type": "application/json",
+            "authx": authx,
+        }
+        if self.token:
+            headers["Authorization"] = self.token
+
+        # 3. 发送请求并处理异常
+        try:
+            response = self.session.request(
+                method,
+                url,
+                headers=headers,
+                params=params,
+                json=data if data is not None else {}
+            )
+            response.raise_for_status()  # 对 4xx/5xx 响应抛出异常
+            response_data = response.json()
+        except requests.exceptions.RequestException as e:
+            print(f"飞牛影视: 请求 {url} 时出错: {e}")
+            return None
+        except json.JSONDecodeError:
+            print(f"飞牛影视: 解析来自 {url} 的响应失败，内容非JSON格式。")
+            return None
+
+        # 4. 统一处理API层面的错误
+        if response_data.get("code") != 0:
+            msg = response_data.get('msg', '未知错误')
+            print(f"飞牛影视: API调用失败 ({rel_url}): {msg}")
+
+        # 5. 返回响应
+        return response_data
+
+    def _login(self, username: str, password: str, app_name: str) -> bool:
+        """
+        登录到飞牛影视服务器并获取认证token。
+        成功后，token会自动存储在客户端实例中。
+        """
+        print("飞牛影视: 正在尝试登录...")
+        rel_url = "/v/api/v1/login"
+        payload = {
+            "username": username,
+            "password": password,
+            "app_name": app_name,
+        }
+        response_json = self._make_request('post', rel_url, data=payload)
+
+        if response_json and response_json["data"]["token"]:
+            self.token = response_json["data"]["token"]
+            print("飞牛影视: 登录成功 ✅")
+            return True
+        else:
+            print("飞牛影视: 登录失败 ❌")
+            return False
+
+    def _get_library_id(self, library_name: str) -> Optional[str]:
+        """
+        根据媒体库的名称获取其唯一ID (guid)。
+        """
+        if not self.token:
+            print("飞牛影视: 必须先登录才能获取媒体库列表。")
+            return None
+
+        print(f"飞牛影视: 正在查找媒体库 '{library_name}'...")
+        rel_url = "/v/api/v1/mdb/list"
+        response_json = self._make_request('get', rel_url)
+
+        if response_json and response_json.get("data"):
+            libraries = response_json.get("data", [])
+            for library in libraries:
+                if library.get("name") == library_name:
+                    print(f"飞牛影视: 找到目标媒体库 ✅，ID: {library.get('guid')}")
+                    return library.get("guid")
+            print(f"飞牛影视: 未在媒体库列表中找到名为 '{library_name}' 的媒体库 ❌")
+        return None
+
+    def _refresh_library(self, library_id: str) -> bool:
+        """
+        根据给定的媒体库ID触发一次媒体库扫描/刷新。
+        """
+        if not self.token:
+            print("飞牛影视: 必须先登录才能刷新媒体库。")
+            return False
+
+        print(f"飞牛影视: 正在为媒体库 {library_id} 发送刷新指令...")
+        rel_url = f"/v/api/v1/mdb/scan/{library_id}"
+        response_json = self._make_request('post', rel_url, data={})  # POST一个空对象
+        response_code = response_json.get("code")
+        if 0 == response_code:
+            print(f"飞牛影视: 发送刷新指令成功 ✅")
+            return True
+        elif response_code == -14:
+            if self._stop_refresh_task(library_id):
+                print(f"飞牛影视: 发现重复任务，已停止旧任务，重新发送刷新指令...")
+                response_json = self._make_request('post', rel_url, data={})  # POST一个空对象
+                response_code = response_json.get("code")
+                if 0 == response_code:
+                    print(f"飞牛影视: 发送刷新指令成功 ✅")
+                    return True
+                else:
+                    print(f"飞牛影视: 重新发送刷新指令失败 ❌")
+            else:
+                print(f"飞牛影视: 停止旧任务失败，无法继续刷新操作 ❌")
+        return False
+
+    def _stop_refresh_task(self, library_id: str) -> bool:
+        """
+        停止指定的媒体库刷新任务。
+        """
+        if not self.token:
+            print("飞牛影视: 必须先登录才能停止刷新任务。")
+            return False
+
+        print(f"飞牛影视: 正在停止媒体库刷新任务 {library_id}...")
+        rel_url = f"/v/api/v1/task/stop"
+        response_json = self._make_request('post', rel_url, data={
+            "guid": library_id,
+            "type": "TaskItemScrap"
+        })
+        response_code = response_json.get("code")
+        if 0 == response_code:
+            print(f"飞牛影视: 停止刷新任务成功 ✅")
+            return True
+        else:
+            print(f"飞牛影视: 停止刷新任务失败 ❌")
+            return False
+
+    def _cse_sign(self, method: str, path: str, params: dict = None, data: dict = None) -> str:
+        """
+        为API请求生成 cse 签名参数字符串。
+        """
+        nonce = str(random.randint(100000, 999999))
+        timestamp = str(int(time.time() * 1000))
+
+        if method.lower() == 'get' and params:
+            serialized_str = urlencode(sorted(params.items()))
+        else:
+            # 对于POST/PUT等方法，序列化body
+            serialized_str = self._serialize_data(data)
+        body_hash = self._md5_hash(serialized_str)
+
+        string_to_sign_parts = [
+            self.secret_string,
+            path,
+            nonce,
+            timestamp,
+            body_hash,
+            self.api_key
+        ]
+        string_to_sign = "_".join(string_to_sign_parts)
+        final_sign = self._md5_hash(string_to_sign)
+
+        return f"nonce={nonce}&timestamp={timestamp}&sign={final_sign}"
+
+    @staticmethod
+    def _md5_hash(s: str) -> str:
+        """计算并返回字符串的小写 MD5 哈希值。"""
+        return hashlib.md5(s.encode('utf-8')).hexdigest()
+
+    @staticmethod
+    def _serialize_data(data: Any) -> str:
+        """
+        将请求体数据序列化为紧凑的JSON字符串。
+        - 字典 (包括`{}`) 会被正确序列化为JSON字符串 (例如 `"{}"`)。
+        - 字符串会原样返回。
+        - 其他`None`或falsy值会返回空字符串`""`。
+        """
+        # 优先检查dict，因为空字典`{}`在Python中为falsy。
+        # 这样可以确保 `{}` 被正确序列化为字符串 `"{}"`。
+        if isinstance(data, dict):
+            return json.dumps(data, sort_keys=True, separators=(',', ':'))
+        if isinstance(data, str):
+            return data
+            # 对于其他 falsy 值（如 None, []），返回空字符串。
+        if not data:
+            return ""
+            # 其他情况（虽然少见），返回空字符串以保证安全。
+        return ""

--- a/plugins/fnv.py
+++ b/plugins/fnv.py
@@ -3,11 +3,15 @@ import json
 import hashlib
 import random
 import time
-from urllib.parse import urlencode, urlsplit
+from urllib.parse import urlencode
 from typing import Any, Optional
 
 
+# 飞牛影视插件
+# 该插件用于与飞牛影视服务器API交互，支持自动刷新媒体库
+# 通过配置用户名、密码和密钥字符串进行认证，并提供媒体库扫描功能
 class Fnv:
+    # --- 配置信息 ---
     default_config = {
         "base_url": "http://10.0.0.6:5666",  # 飞牛影视服务器URL
         "app_name": "trimemedia-web",  # 飞牛影视应用名称
@@ -15,6 +19,7 @@ class Fnv:
         "password": "",  # 飞牛影视密码
         "secret_string": "",  # 飞牛影视密钥字符串
         "api_key": "",  # 飞牛影视API密钥
+        "token": None,  # 飞牛影视认证Token (可选)
     }
 
     default_task_config = {
@@ -22,118 +27,159 @@ class Fnv:
         "mdb_name": "",  # 飞牛影视目标媒体库名称
     }
 
+    # 定义一个可选键的集合
+    OPTIONAL_KEYS = {"token"}
+
+    # --- API 端点常量 ---
+    API_LOGIN = "/v/api/v1/login"  # 登录端点
+    API_MDB_LIST = "/v/api/v1/mdb/list"  # 获取媒体库列表
+    API_MDB_SCAN = "/v/api/v1/mdb/scan/{}"  # 刷新媒体库端点 ({}为媒体库ID)
+    API_TASK_STOP = "/v/api/v1/task/stop"  # 停止任务端点
+
+    # --- 实例状态 ---
     is_active = False
-    token = None
     session = requests.Session()
+    token = None
+
+    # =====================================================================
+    # Public Methods / Entry Points (公共方法/入口)
+    # =====================================================================
 
     def __init__(self, **kwargs):
+        """
+        初始化 Fnv 客户端。
+        """
         self.plugin_name = self.__class__.__name__.lower()
         if kwargs:
             for key, _ in self.default_config.items():
                 if key in kwargs:
                     setattr(self, key, kwargs[key])
-            self.is_active = self._check_config()
+            # 检查配置并尝试登录，以确定插件是否激活
+            if self._check_config():
+                if self.token is None or self.token == "":
+                    self._login()
+                self.is_active = self.token is not None or self.token != ""
+                if self.is_active:
+                    print(f"{self.plugin_name}: 插件已激活 ✅")
+                else:
+                    print(f"{self.plugin_name}: 插件未激活 ❌")
+
+    def run(self, task, **kwargs):
+        """
+        插件运行主入口。
+        根据任务配置，执行媒体库刷新操作。
+        """
+        if not self.is_active:
+            print(f"飞牛影视: 插件未激活，跳过任务。")
+            return
+
+        task_config = task.get("addition", {}).get(
+            self.plugin_name, self.default_task_config
+        )
+        if not task_config.get("auto_refresh"):
+            print("飞牛影视: 自动刷新未启用，跳过处理。")
+            return
+
+        target_library_name = task_config.get("mdb_name")
+        if not target_library_name:
+            print("飞牛影视: 未指定媒体库名称，跳过处理。")
+            return
+
+        # 获取媒体库ID
+        library_id = self._get_library_id(target_library_name)
+
+        if library_id:
+            # 获取ID成功后，刷新该媒体库
+            self._refresh_library(library_id)
+
+    # =====================================================================
+    # Internal Methods (内部实现方法)
+    # =====================================================================
 
     def _check_config(self):
         """检查配置是否完整"""
         missing_keys = [
-            key for key in self.default_config if not getattr(self, key, None)
+            key for key in self.default_config
+            if key not in self.OPTIONAL_KEYS and not getattr(self, key, None)
         ]
         if missing_keys:
             print(f"{self.plugin_name} 模块缺少必要参数: {', '.join(missing_keys)}")
             return False
         return True
 
-    def run(self, task, **kwargs):
-        """插件运行主入口"""
-        if not self.is_active:
-            return
-        task_config = task.get("addition", {}).get(
-            self.plugin_name, self.default_task_config
-        )
-        if not task_config.get("auto_refresh"):
-            print("飞牛影视: 自动刷新未启用，跳过处理")
-            return
-        if not task_config.get("mdb_name"):
-            print("飞牛影视: 未指定媒体库名称，跳过处理")
-            return
-        target_library_name = task_config["mdb_name"]
-        app_name = self.app_name or self.default_config["app_name"]
-        username = self.username or self.default_config["username"]
-        password = self.password or self.default_config["password"]
-
-        # 登录并执行后续操作
-        if self._login(username=username, password=password, app_name=app_name):
-
-            # 登录成功后，获取媒体库ID
-            library_id = self._get_library_id(target_library_name)
-
-            if library_id:
-                # 获取ID成功后，刷新该媒体库
-                self._refresh_library(library_id)
-
     def _make_request(self, method: str, rel_url: str, params: dict = None, data: dict = None) -> Optional[Any]:
         """
         一个统一的私有方法，用于发送所有API请求。
         它会自动处理签名、请求头、错误和响应解析。
+        当认证失败时，会自动尝试重新登录并重试，最多3次。
         """
-        url = f"{self.base_url.rstrip('/')}{rel_url}"
+        max_retries = 3
+        for attempt in range(max_retries):
+            url = f"{self.base_url.rstrip('/')}{rel_url}"
 
-        # 1. 生成认证签名
-        authx = self._cse_sign(method, rel_url, params, data)
-        if not authx:
-            print(f"飞牛影视: 为 {rel_url} 生成签名失败，请求中止。")
-            return None
+            authx = self._cse_sign(method, rel_url, params, data)
+            if not authx:
+                print(f"飞牛影视: 为 {rel_url} 生成签名失败，请求中止。")
+                return None
 
-        # 2. 准备请求头
-        headers = {
-            "Content-Type": "application/json",
-            "authx": authx,
-        }
-        if self.token:
-            headers["Authorization"] = self.token
+            headers = {
+                "Content-Type": "application/json",
+                "authx": authx,
+            }
+            if self.token:
+                headers["Authorization"] = self.token
 
-        # 3. 发送请求并处理异常
-        try:
-            response = self.session.request(
-                method,
-                url,
-                headers=headers,
-                params=params,
-                json=data if data is not None else {}
-            )
-            response.raise_for_status()  # 对 4xx/5xx 响应抛出异常
-            response_data = response.json()
-        except requests.exceptions.RequestException as e:
-            print(f"飞牛影视: 请求 {url} 时出错: {e}")
-            return None
-        except json.JSONDecodeError:
-            print(f"飞牛影视: 解析来自 {url} 的响应失败，内容非JSON格式。")
-            return None
+            try:
+                response = self.session.request(
+                    method, url, headers=headers, params=params, json=data if data is not None else {}
+                )
+                response.raise_for_status()
+                response_data = response.json()
+            except requests.exceptions.RequestException as e:
+                print(f"飞牛影视: 请求 {url} 时出错: {e}")
+                return None
+            except json.JSONDecodeError:
+                print(f"飞牛影视: 解析来自 {url} 的响应失败，内容非JSON格式。")
+                return None
 
-        # 4. 统一处理API层面的错误
-        if response_data.get("code") != 0:
-            msg = response_data.get('msg', '未知错误')
-            print(f"飞牛影视: API调用失败 ({rel_url}): {msg}")
+            response_code = response_data.get("code")
+            if response_code is None:
+                print(f"飞牛影视: 响应格式错误，未找到 'code' 字段。")
+                return None
 
-        # 5. 返回响应
-        return response_data
+            if response_code == 0:
+                return response_data
 
-    def _login(self, username: str, password: str, app_name: str) -> bool:
+            if response_code == -2:
+                print(f"飞牛影视: 认证失败 (尝试 {attempt + 1}/{max_retries})，尝试重新登录...")
+                if rel_url == self.API_LOGIN:
+                    print("飞牛影视: 登录接口认证失败，请检查用户名和密码。")
+                    return response_data
+                if not self._login():
+                    print("飞牛影视: 重新登录失败，无法继续请求。")
+                    return None
+                continue
+            else:
+                msg = response_data.get('msg', '未知错误')
+                print(f"飞牛影视: API调用失败 ({rel_url}): {msg}")
+                return response_data
+
+        print(f"飞牛影视: 请求 {rel_url} 在尝试 {max_retries} 次后仍然失败。")
+        return None
+
+    def _login(self) -> bool:
         """
         登录到飞牛影视服务器并获取认证token。
-        成功后，token会自动存储在客户端实例中。
         """
+        app_name = self.app_name or self.default_config["app_name"]
+        username = self.username or self.default_config["username"]
+        password = self.password or self.default_config["password"]
         print("飞牛影视: 正在尝试登录...")
-        rel_url = "/v/api/v1/login"
-        payload = {
-            "username": username,
-            "password": password,
-            "app_name": app_name,
-        }
-        response_json = self._make_request('post', rel_url, data=payload)
 
-        if response_json and response_json["data"]["token"]:
+        payload = {"username": username, "password": password, "app_name": app_name}
+        response_json = self._make_request('post', self.API_LOGIN, data=payload)
+
+        if response_json and response_json.get("data", {}).get("token"):
             self.token = response_json["data"]["token"]
             print("飞牛影视: 登录成功 ✅")
             return True
@@ -150,12 +196,10 @@ class Fnv:
             return None
 
         print(f"飞牛影视: 正在查找媒体库 '{library_name}'...")
-        rel_url = "/v/api/v1/mdb/list"
-        response_json = self._make_request('get', rel_url)
+        response_json = self._make_request('get', self.API_MDB_LIST)
 
         if response_json and response_json.get("data"):
-            libraries = response_json.get("data", [])
-            for library in libraries:
+            for library in response_json.get("data", []):
                 if library.get("name") == library_name:
                     print(f"飞牛影视: 找到目标媒体库 ✅，ID: {library.get('guid')}")
                     return library.get("guid")
@@ -171,18 +215,20 @@ class Fnv:
             return False
 
         print(f"飞牛影视: 正在为媒体库 {library_id} 发送刷新指令...")
-        rel_url = f"/v/api/v1/mdb/scan/{library_id}"
-        response_json = self._make_request('post', rel_url, data={})  # POST一个空对象
+        rel_url = self.API_MDB_SCAN.format(library_id)
+        response_json = self._make_request('post', rel_url, data={})
+
+        if not response_json: return False
+
         response_code = response_json.get("code")
-        if 0 == response_code:
+        if response_code == 0:
             print(f"飞牛影视: 发送刷新指令成功 ✅")
             return True
         elif response_code == -14:
             if self._stop_refresh_task(library_id):
                 print(f"飞牛影视: 发现重复任务，已停止旧任务，重新发送刷新指令...")
-                response_json = self._make_request('post', rel_url, data={})  # POST一个空对象
-                response_code = response_json.get("code")
-                if 0 == response_code:
+                response_json = self._make_request('post', rel_url, data={})
+                if response_json and response_json.get("code") == 0:
                     print(f"飞牛影视: 发送刷新指令成功 ✅")
                     return True
                 else:
@@ -200,13 +246,10 @@ class Fnv:
             return False
 
         print(f"飞牛影视: 正在停止媒体库刷新任务 {library_id}...")
-        rel_url = f"/v/api/v1/task/stop"
-        response_json = self._make_request('post', rel_url, data={
-            "guid": library_id,
-            "type": "TaskItemScrap"
-        })
-        response_code = response_json.get("code")
-        if 0 == response_code:
+        payload = {"guid": library_id, "type": "TaskItemScrap"}
+        response_json = self._make_request('post', self.API_TASK_STOP, data=payload)
+
+        if response_json and response_json.get("code") == 0:
             print(f"飞牛影视: 停止刷新任务成功 ✅")
             return True
         else:
@@ -223,22 +266,20 @@ class Fnv:
         if method.lower() == 'get' and params:
             serialized_str = urlencode(sorted(params.items()))
         else:
-            # 对于POST/PUT等方法，序列化body
             serialized_str = self._serialize_data(data)
         body_hash = self._md5_hash(serialized_str)
 
         string_to_sign_parts = [
-            self.secret_string,
-            path,
-            nonce,
-            timestamp,
-            body_hash,
-            self.api_key
+            self.secret_string, path, nonce, timestamp, body_hash, self.api_key
         ]
         string_to_sign = "_".join(string_to_sign_parts)
         final_sign = self._md5_hash(string_to_sign)
 
         return f"nonce={nonce}&timestamp={timestamp}&sign={final_sign}"
+
+    # =====================================================================
+    # Static Utility Methods (静态工具方法)
+    # =====================================================================
 
     @staticmethod
     def _md5_hash(s: str) -> str:
@@ -249,18 +290,11 @@ class Fnv:
     def _serialize_data(data: Any) -> str:
         """
         将请求体数据序列化为紧凑的JSON字符串。
-        - 字典 (包括`{}`) 会被正确序列化为JSON字符串 (例如 `"{}"`)。
-        - 字符串会原样返回。
-        - 其他`None`或falsy值会返回空字符串`""`。
         """
-        # 优先检查dict，因为空字典`{}`在Python中为falsy。
-        # 这样可以确保 `{}` 被正确序列化为字符串 `"{}"`。
         if isinstance(data, dict):
             return json.dumps(data, sort_keys=True, separators=(',', ':'))
         if isinstance(data, str):
             return data
-            # 对于其他 falsy 值（如 None, []），返回空字符串。
         if not data:
             return ""
-            # 其他情况（虽然少见），返回空字符串以保证安全。
         return ""


### PR DESCRIPTION
简介

- 该插件用于与飞牛影视服务器进行对接：登录、获取媒体库列表、按名称查找目标媒体库并触发扫描刷新。
- 支持自动处理 API 鉴权签名（cse 签名机制）与 Token 管理。
- 支持重复任务检测，若遇到重复任务会尝试停止旧任务并重新触发。

效果图

<img width="1066" height="182" alt="image" src="https://github.com/user-attachments/assets/f65a1648-2d6b-4599-a0f3-d80976defd81" />
<img width="756" height="254" alt="image" src="https://github.com/user-attachments/assets/b8f4e03b-5cdb-4ddf-8614-e26e41d776de" />


运行流程

1. 校验全局配置是否完整（base\_url、app\_name、username、password、secret\_string、api\_key）。
2. 从任务参数中读取是否开启自动刷新与目标媒体库名称。
3. 登录后获取媒体库列表，找到目标媒体库的 guid。
4. 调用媒体库扫描接口触发刷新。
5. 若返回重复任务（code\=-14），先停止旧任务再重试刷新。

集成与调用

- 初始化：fnv \= Fnv(\*\*config)
- 执行：fnv.run(task\_dict)
- task\_dict 结构需包含 addition.fnv，示例见下方“任务配置示例”。

全局配置参数（default\_config）

- base\_url

  - 类型：字符串
  - 说明：飞牛影视服务器的基础 URL，包含协议与端口。
  - 示例：[http://10.0.0.6:5666/](http://10.0.0.6:5666/)
  - 获取方式：自行填写
- app\_name

  - 类型：字符串
  - 说明：飞牛影视应用名称（用于登录）。
  - 示例：trimemedia-web
  - 获取方式：暂时固定
- username

  - 类型：字符串
  - 说明：飞牛影视用户名（用于登录）。
  - 示例：admin
  - 获取方式：自行填写
- password

  - 类型：字符串
  - 说明：飞牛影视密码（用于登录）。
  - 获取方式：自行填写
- api\_key

  - 类型：字符串
  - 说明：飞牛影视 API Key，参与 cse 签名拼接。
  - 获取方式：

    - F12打开开发者工具
    - 全局按正则搜索(window下快捷键:Ctrl+Shift+F)

      ```json
      [0-9a-f]{8}(-[0-9a-f]{4}){3}-[0-9a-f]{12}
      ```
    - <img width="2553" height="568" alt="image" src="https://github.com/user-attachments/assets/29247d9c-10ba-40d1-8f83-26251b94f8f4" />
- secret\_string

  - 类型：字符串
  - 说明：飞牛影视 API 签名所需的“密钥字符串”，参与 cse 签名拼接。
  - 获取方式：

    - 与api\_key在同一个js文件内，在文件内搜索(window下快捷键:Ctrl+F)字符串

      ```json
      Date.now() + ""
      ```
    - <img width="1694" height="521" alt="image" src="https://github.com/user-attachments/assets/7a40ac10-843c-479d-aa6f-1e3143b8f12c" />

任务级配置参数（default\_task\_config）

- auto\_refresh

  - 类型：布尔
  - 说明：是否自动刷新媒体库。为 False 时插件跳过处理。
  - 示例：true
- mdb\_name

  - 类型：字符串
  - 说明：目标媒体库名称（与飞牛影视媒体库名称完全匹配）。
  - 示例：电影库

任务配置示例

- 以 Python 字典为例： { "addition": { "fnv": { "auto\_refresh": true, "mdb\_name": "电影库" } } }
- 初始化与调用示例（请按需传入参数值）： fnv \= Fnv( base\_url\="[http://10.0.0.6:5666](http://10.0.0.6:5666/)", app\_name\="trimemedia-web", username\="", password\="", secret\_string\="", api\_key\="" ) task \= { "addition": { "fnv": { "auto\_refresh": True, "mdb\_name": "电影库" } } } fnv.run(task)

使用到的飞牛接口

- 登录

  - 方法：POST
  - 路径：/v/api/v1/login
  - 请求体：{"username": "...", "password": "...", "app\_name": "..."}
  - 响应：code\=0 且 data.token 存在则登录成功
  - 请求头：Content-Type: application/json, authx: \<签名参数\>
- 获取媒体库列表

  - 方法：GET
  - 路径：/v/api/v1/mdb/list
  - 响应：code\=0 且 data 为媒体库数组，每项包含 name、guid 等
  - 请求头：Authorization: \<token\>, authx: \<签名参数\>
- 触发媒体库扫描

  - 方法：POST
  - 路径：/v/api/v1/mdb/scan/{library\_id}
  - 请求体：{}
  - 响应：code\=0 表示发送刷新指令成功；code\=-14 表示重复任务
- 停止刷新任务

  - 方法：POST
  - 路径：/v/api/v1/task/stop
  - 请求体：{"guid": "\<library\_id\>", "type": "TaskItemScrap"}
  - 响应：code\=0 表示停止成功

鉴权与签名说明（cse 签名）

- 插件会在每次请求时自动生成 authx 头部，格式如下： authx: nonce\=\<随机数\>&timestamp\=\<毫秒时间戳\>&sign\=\<md5签名\>
- 签名步骤：

  1. 生成随机 nonce（6位数字）与 timestamp（毫秒）。
  2. 计算 body\_hash：

      - GET：对 params 进行按 key 排序后 urlencode，再 md5。
      - 非 GET：将请求体 JSON 使用排序+紧凑序列化（separators\=(',', ':'), sort\_keys\=True），再 md5。空对象 {} 也会被序列化为 "{}"。
  3. 待签名字符串： secret\_string + " *" + path + "* " + nonce + " *" + timestamp + "* " + body\_hash + "\_" + api\_key
  4. 对上述字符串再做一次 md5 得到 sign。
  5. 组装为 authx 头。
- 额外头部：

  - 登录成功后，后续请求会带上 Authorization: \<token\>
  - Content-Type: application/json

日志与返回

- 主要日志包含：配置校验、登录成功/失败、查找媒体库结果、刷新指令结果、重复任务处理结果等。
- API 非 0 code 会在日志中提示“API调用失败”。

常见问题与排查

- 登录失败

  - 排查：确认 base\_url 可访问、app\_name/username/password/secret\_string/api\_key 是否正确、服务器时间是否与客户端相差过大（影响签名中的时间戳）。
- 未找到媒体库

  - 排查：mdb\_name 是否与飞牛媒体库名称完全一致（大小写、空格）。
- 刷新指令重复（code\=-14）

  - 插件会自动尝试停止旧任务再重发；若仍失败，检查任务系统是否卡死或权限不足。
- 解析响应失败

  - 检查服务器返回是否为 JSON；确认服务器版本兼容。

注意事项

- default\_config 中所有参数为必填，任一缺失将导致插件不激活。
- base\_url 末尾不必加斜杠，插件会自动处理。
- mdb\_name 必须是“名称匹配”，不是 guid。
- 请妥善保管 secret\_string 和 api\_key，避免泄露。
- 接口路径与 code 语义依赖于飞牛影视版本，若版本不同可能需要适配。