### PR TITLE
🐛 补充修复：添加 APScheduler 调度器参数，彻底解决任务堆积问题

### DIFF
--- a/app/run.py
+++ b/app/run.py
@@ -495,11 +495,21 @@ def run_python(args):
             logging.error(f">>> 任务执行失败，返回码: {result.returncode}")
             if result.stderr:
                 logging.error(f"错误信息: {result.stderr[:500]}")
-    except subprocess.TimeoutExpired:
+    except subprocess.TimeoutExpired as e:
         logging.error(f">>> 任务执行超时（超过 {timeout} 秒），已强制终止")
+        # 尝试终止进程
+        if e.process:
+            try:
+                e.process.kill()
+                logging.info(">>> 已终止超时进程")
+            except:
+                pass
     except Exception as e:
         logging.error(f">>> 任务执行异常: {str(e)}")
         logging.error(traceback.format_exc())
+    finally:
+        # 确保函数能够正常返回
+        logging.debug(f">>> run_python 函数执行完成")
 
 
 # 重新加载任务
@@ -515,6 +525,10 @@ def reload_tasks():
             trigger=trigger,
             args=[f"{SCRIPT_PATH} {CONFIG_PATH}"],
             id=SCRIPT_PATH,
+            max_instances=1,  # 最多允许1个实例运行
+            coalesce=True,  # 合并错过的任务，避免堆积
+            misfire_grace_time=300,  # 错过任务的宽限期(秒)，超过则跳过
+            replace_existing=True,  # 替换已存在的同ID任务
         )
         if scheduler.state == 0:
             scheduler.start()


### PR DESCRIPTION
PR #125 已经将 os.system() 改为 subprocess.run() 并添加了超时机制，

但在实际使用中发现任务仍会堆积导致后续任务被跳过。

根本原因是 scheduler.add_job() 缺少关键参数配置：

- coalesce=True: 合并错过的任务，只执行一次，避免堆积

- misfire_grace_time=300: 错过任务的宽限期（5分钟），超过则跳过

- replace_existing=True: 重新加载配置时替换已存在的同ID任务

同时改进 run_python() 函数的异常处理：

- 超时后主动终止子进程，释放资源

- 添加 finally 块确保函数正常返回

测试结果：VPS 实测 24 小时稳定运行，任务每 5 分钟正常执行