### PR TITLE
任务保存规则支持以魔法匹配为模板调整正则表达式

### DIFF
--- a/app/templates/index.html
+++ b/app/templates/index.html
@@ -379,7 +379,7 @@
                         <div class="input-group-prepend">
                           <button class="btn btn-outline-secondary" type="button" @click="fileSelect.selectDir=true;fileSelect.switchShare=false;fileSelect.previewRegex=true;fileSelect.sortBy='file_name';fileSelect.sortOrder='asc';showShareSelect(index)" title="预览正则处理效果">正则处理</button>
                         </div>
-                        <input type="text" name="pattern[]" class="form-control" v-model="task.pattern" placeholder="匹配表达式" list="magicRegex" @change="changeMagicRegex(task)">
+                        <input type="text" name="pattern[]" class="form-control" v-model="task.pattern" placeholder="匹配表达式" list="magicRegex" @dblclick="inputRawMagicRegex(task)" title="双击可将魔法匹配释放为填入原始正则表达式">
                         <input type="text" name="replace[]" class="form-control" v-model="task.replace" placeholder="替换表达式">
                         <div class="input-group-append" title="保存时只比较文件名的部分，01.mp4 和 01.mkv 视同为同一文件，不重复转存">
                           <div class="input-group-text">
@@ -1246,7 +1246,7 @@
             return 0;
           });
         },
-        changeMagicRegex(task) {
+        inputRawMagicRegex(task) {
           const item = this.formData.magic_regex[task.pattern];
           if (item) {
             task.pattern = item.pattern;


### PR DESCRIPTION
**需求：**

魔法匹配定义的匹配表达式无法满足网盘各种各样的命名格式，但有时只需要在魔法匹配的基础上稍加修改便可以满足特定任务的要求。
在当前逻辑下，使用魔法匹配时无法修改匹配表达式的内容，需完整手动输入匹配表达式，操作稍加麻烦。

**优化：**

任务保存规则选择魔法匹配时，自动带入魔法匹配预设的匹配表达式与替换表达式，用户可选择使用默认预设模板或手动进行修改，同时也支持原魔法匹配 `$TV_MAGIC` 的格式。

**问题：**

修改后新建任务时保存规则无法再输入 `$TV_MAGIC` 格式，因为会被自动带入的匹配表达式与替换表达式覆盖掉，但不影响已有任务的运行。
或许此处操作逻辑作者可优化一下，同时兼容 `$TV_MAGIC` 格式输入与基于魔法匹配进行修改👍。