### PR TITLE
修复 alist_sync 在新建夸克目录后立即读取失败的问题

### DIFF
--- a/plugins/alist_sync.py
+++ b/plugins/alist_sync.py
@@ -3,6 +3,7 @@
 
 import re
 import json
+import time
 import requests
 
 
@@ -280,12 +281,45 @@ class Alist_sync:
         payload = json.dumps(
             {"path": path, "password": "", "page": 1, "per_page": 0, "refresh": True}
         )
-        response = self._send_request("POST", url, data=payload)
-        if response.status_code != 200:
-            print(f"获取Alist目录出错: {response}")
-            return False
-        else:
-            return response.json()["data"]["content"]
+        parent_path = "/" if path in ("", "/") else path.rsplit("/", 1)[0] or "/"
+        parent_payload = json.dumps(
+            {
+                "path": parent_path,
+                "password": "",
+                "page": 1,
+                "per_page": 0,
+                "refresh": True,
+            }
+        )
+        last_error = "unknown"
+        for attempt in range(4):
+            response = self._send_request("POST", url, data=payload)
+            if response.status_code != 200:
+                last_error = f"http {response.status_code}"
+            else:
+                try:
+                    data = response.json()
+                except Exception as e:
+                    last_error = f"invalid json: {e}"
+                else:
+                    if data.get("code") == 200 and isinstance(data.get("data"), dict):
+                        content = data["data"].get("content")
+                        if content is not None:
+                            return content
+                        last_error = "content is null"
+                    else:
+                        last_error = data.get("message") or "data is null"
+            if "object not found" in str(last_error).lower() and parent_path != path:
+                print(f"Alist目标目录不存在，先刷新父目录: {parent_path}")
+                self._send_request("POST", url, data=parent_payload)
+            if attempt < 3:
+                print(
+                    f"Alist目录暂不可读，稍后重试({attempt+1}/4): "
+                    f"{path} -> {last_error}"
+                )
+                time.sleep(2)
+        print(f"获取Alist目录失败: {path} -> {last_error}")
+        return False
 
     def get_path(self, path):
         url = f"{self.url}/api/fs/list"

--- a/tests/test_alist_sync.py
+++ b/tests/test_alist_sync.py
@@ -1,0 +1,89 @@
+import json
+import unittest
+from unittest.mock import patch
+
+from plugins.alist_sync import Alist_sync
+
+
+class FakeResponse:
+    def __init__(self, status_code, payload):
+        self.status_code = status_code
+        self._payload = payload
+
+    def json(self):
+        return self._payload
+
+
+class AlistSyncPathListTests(unittest.TestCase):
+    def build_plugin(self):
+        plugin = Alist_sync()
+        plugin.url = "http://alist.local"
+        plugin.token = "token"
+        return plugin
+
+    def test_refresh_parent_directory_when_child_not_found(self):
+        plugin = self.build_plugin()
+        calls = []
+        responses = [
+            FakeResponse(
+                200,
+                {
+                    "code": 500,
+                    "message": "failed get objs: failed get dir: object not found",
+                    "data": None,
+                },
+            ),
+            FakeResponse(
+                200,
+                {"code": 200, "message": "success", "data": {"content": []}},
+            ),
+            FakeResponse(
+                200,
+                {
+                    "code": 200,
+                    "message": "success",
+                    "data": {"content": [{"name": "demo-file.mkv"}]},
+                },
+            ),
+        ]
+
+        def fake_send(method, url, data=None, **kwargs):
+            calls.append(json.loads(data))
+            return responses.pop(0)
+
+        plugin._send_request = fake_send
+
+        with patch("plugins.alist_sync.time.sleep", return_value=None):
+            result = plugin.get_path_list("/kuake/video/demo")
+
+        self.assertEqual([{"name": "demo-file.mkv"}], result)
+        self.assertEqual("/kuake/video/demo", calls[0]["path"])
+        self.assertEqual("/kuake/video", calls[1]["path"])
+        self.assertEqual("/kuake/video/demo", calls[2]["path"])
+
+    def test_return_false_when_alist_returns_null_data(self):
+        plugin = self.build_plugin()
+        calls = []
+        responses = [
+            FakeResponse(
+                200,
+                {"code": 500, "message": "transient", "data": None},
+            )
+            for _ in range(4)
+        ]
+
+        def fake_send(method, url, data=None, **kwargs):
+            calls.append(json.loads(data))
+            return responses.pop(0)
+
+        plugin._send_request = fake_send
+
+        with patch("plugins.alist_sync.time.sleep", return_value=None):
+            result = plugin.get_path_list("/kuake/video/demo")
+
+        self.assertFalse(result)
+        self.assertEqual(4, len(calls))
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## 变更说明

这个 PR 修复了 `alist_sync` 在“夸克刚创建并转存完新目录后，AList/OpenList 侧暂时还读不到该子目录”时的失败问题。

之前 `get_path_list()` 在 HTTP 200 时直接读取：

```python
response.json()["data"]["content"]
```

当 AList 返回 `data: null` 或 `failed get objs: failed get dir: object not found` 时，会直接报错，或者在短暂时序窗口内直接失败。

这个 PR 做了两件事：

1. 为 `response.json()` 增加了空值和结构校验，避免 `data` 为 `null` 时直接崩溃。
2. 当目标子目录返回 `object not found` 时，先显式刷新父目录，再重试目标子目录。

## 触发场景

典型场景是：

- 任务保存路径是一个全新的目录，例如 `video/杀木地11111`
- 夸克保存本身已经成功，文件已经转存完成
- 紧接着执行 `alist_sync`
- AList 此时对新子目录的读取仍可能短暂返回 `object not found` 或 `data: null`

此时只对目标子目录自己重试，成功率不稳定；先刷新父目录后再重试子目录，会更符合实际行为。

## 验证

已新增最小单元测试，覆盖两类情况：

- 子目录首次返回 `object not found`，刷新父目录后再次读取成功
- AList 连续返回 `data: null` / 非成功响应时，不再抛异常，而是安全返回 `False`

本地验证命令：

```bash
python -m unittest tests/test_alist_sync.py
python -m py_compile plugins/alist_sync.py
```

## 关联

- 参考 `#14` 中对 Issue 质量的要求，这个 PR 直接给出问题定位、修改方案和验证。
- 修复 `#172`
